### PR TITLE
refactor: migrate neural and stats trainers to BaseMLTrainer

### DIFF
--- a/ml/training/neural_forecast.py
+++ b/ml/training/neural_forecast.py
@@ -22,6 +22,8 @@ from sklearn.metrics import mean_squared_error
 
 warnings.filterwarnings("ignore")
 
+from ml.training.base import BaseMLTrainer
+
 from ..config.settings import Settings
 from ..data.unified_loader import UnifiedNautilusDataLoader
 from ..features.feature_engineering import FeatureConfig
@@ -31,7 +33,6 @@ from ..features.feature_engineering import FeatureEngineerV2
 from ..resource_management.trainer_mixin import ResourceManagedTrainerMixin
 from ..utils.dataframe_converter import DataFrameConverter
 from ..utils.mlflow_utils import MLflowManager
-from .base_trainer import BaseTrainer
 
 
 # Try to import Neural Forecast libraries
@@ -54,7 +55,7 @@ except ImportError:
     print("Warning: NeuralForecast not available. Install with: pip install neuralforecast")
 
 
-class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
+class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseMLTrainer):
     """
     Neural Forecast trainer supporting multiple transformer models.
 
@@ -80,6 +81,7 @@ class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
     """
 
     def __init__(self, config: dict[str, Any], settings: Settings | None = None):
+        self.settings = settings
         self.mlflow_manager = MLflowManager(settings)
         """
         Initialize Neural Forecast trainer.
@@ -98,7 +100,7 @@ class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
             settings: Nautilus ML settings object
 
         """
-        super().__init__(config, settings)
+        super().__init__(config)
 
         if not NEURALFORECAST_AVAILABLE:
             raise ImportError(

--- a/ml/training/statsforecast.py
+++ b/ml/training/statsforecast.py
@@ -31,6 +31,8 @@ from statsmodels.graphics.tsaplots import plot_acf
 from statsmodels.graphics.tsaplots import plot_pacf
 from statsmodels.stats.diagnostic import acorr_ljungbox
 
+from ml.training.base import BaseMLTrainer
+
 from ..config.settings import Settings
 from ..data.unified_loader import UnifiedNautilusDataLoader
 from ..features.feature_engineering import FeatureConfig
@@ -39,7 +41,6 @@ from ..features.feature_engineering import FeatureEngineerV2
 # Moved to conditional import to avoid circular dependency
 from ..utils.dataframe_converter import DataFrameConverter
 from ..utils.mlflow_utils import MLflowManager
-from .base_trainer import BaseTrainer
 
 
 # Import StatsForecast libraries
@@ -70,7 +71,7 @@ except ImportError:
     )
 
 
-class StatsForecastTrainer(BaseTrainer):
+class StatsForecastTrainer(BaseMLTrainer):
     """
     StatsForecast trainer for fast statistical time series models.
 
@@ -117,7 +118,8 @@ class StatsForecastTrainer(BaseTrainer):
             settings: Nautilus ML settings object
 
         """
-        super().__init__(config, settings)
+        self.settings = settings
+        super().__init__(config)
 
         if not STATSFORECAST_AVAILABLE:
             raise ImportError(
@@ -864,7 +866,7 @@ class StatsForecastTrainer(BaseTrainer):
         """
         Evaluate StatsForecast model performance.
 
-        Note: This is primarily for compatibility with BaseTrainer.
+        Note: This is primarily for compatibility with BaseMLTrainer.
         StatsForecast models are evaluated differently during training.
 
         """


### PR DESCRIPTION
## Summary
- use BaseMLTrainer in neural forecast and statsforecast trainers
- adjust constructors to maintain settings and remove legacy BaseTrainer references

## Testing
- `pre-commit run --files ml/training/neural_forecast.py ml/training/statsforecast.py` *(fails: Item "None" of "Any | None" has no attribute "mlflow"; Signature incompatibilities)*
- `pytest ml/tests/unit/test_base_trainer.py -q` *(fails: ModuleNotFoundError: No module named 'nautilus_trader.core.data')*

------
https://chatgpt.com/codex/tasks/task_e_689580180f4883228f9dcee647d69ed9

## Summary by Sourcery

Migrate neural and stats forecast trainers to use BaseMLTrainer and adjust constructors to maintain settings and remove legacy BaseTrainer usage.

Enhancements:
- Change StatsForecastTrainer and NeuralForecastTrainer to inherit from BaseMLTrainer instead of BaseTrainer
- Explicitly assign settings in each trainer __init__ and pass only config to super()
- Update evaluation docstring to reference BaseMLTrainer for compatibility notes