### PR TITLE
Raise for missing model params

### DIFF
--- a/ml/training/base.py
+++ b/ml/training/base.py
@@ -381,7 +381,6 @@ class BaseMLTrainer(ABC):
         """
         ...
 
-    @abstractmethod
     def _get_model_params(self) -> dict[str, Any]:
         """
         Get model-specific default parameters.
@@ -392,7 +391,9 @@ class BaseMLTrainer(ABC):
             Default model parameters.
 
         """
-        ...
+        if getattr(self._config, "model_params", None) is not None:
+            return self._config.model_params  # type: ignore[return-value]
+        raise NotImplementedError("Subclasses must implement _get_model_params")
 
     def _should_use_mlflow(self) -> bool:
         """


### PR DESCRIPTION
## Summary
- raise NotImplementedError when model params missing
- provide default for model params via config

## Testing
- `pre-commit run --files ml/training/base.py ml/training/xgboost.py ml/training/lightgbm.py` *(fails: multiple mypy errors in unrelated files)*
- `pytest ml/tests/unit/test_base_trainer.py -q` *(fails: No module named 'nautilus_trader.core.data')*

------
https://chatgpt.com/codex/tasks/task_e_68958019e3888322ba12ddf2e866f5f7

## Summary by Sourcery

Allow model parameters to be sourced from the trainer config with a fallback error and enforce subclass overrides only when necessary

Bug Fixes:
- Raise NotImplementedError when no model parameters are provided by config or subclass

Enhancements:
- Allow specifying default model parameters via self._config.model_params
- Remove the abstractmethod requirement from _get_model_params to streamline parameter handling