### PR TITLE
Use explicit validation data in StatsForecast training

### DIFF
--- a/ml/training/statsforecast.py
+++ b/ml/training/statsforecast.py
@@ -290,24 +290,32 @@ class StatsForecastTrainer(BaseTrainer):
         Train StatsForecast models.
 
         Args:
-            train_data: Training data
-            val_data: Validation data (optional)
-            use_optuna: Whether to use Optuna for hyperparameter optimization
-            n_trials: Number of Optuna trials
+            train_data: Training data.
+            val_data: Validation data. If provided, it will be used for evaluation
+                regardless of ``use_optuna``.
+            use_optuna: Whether to use Optuna for hyperparameter optimization.
+            n_trials: Number of Optuna trials.
 
         Returns:
             Dictionary containing trained models and metrics
 
         """
-        # Prepare data
-        train_df, test_df, metadata = self.prepare_data(train_data)
+        # Prepare training and validation data
+        if val_data is not None:
+            train_train_df, train_test_df, metadata = self.prepare_data(train_data)
+            train_df = pd.concat([train_train_df, train_test_df])
 
-        if use_optuna and val_data is not None:
-            # Use Optuna for model selection
-            return self._train_with_optuna(train_df, test_df, n_trials)
+            val_train_df, val_test_df, _ = self.prepare_data(val_data)
+            val_df = pd.concat([val_train_df, val_test_df])
+        else:
+            train_df, val_df, metadata = self.prepare_data(train_data)
+
+        if use_optuna:
+            # Use Optuna for model selection (validation data always used for evaluation)
+            return self._train_with_optuna(train_df, val_df, n_trials)
         else:
             # Train with default parameters
-            return self._train_default(train_df, test_df, metadata)
+            return self._train_default(train_df, val_df, metadata)
 
     def _train_default(
         self,


### PR DESCRIPTION
## Summary
- Prepare training and validation data separately in StatsForecast trainer
- Always evaluate using provided `val_data` regardless of Optuna usage
- Retain internal split when no validation data is supplied

## Testing
- `pre-commit run --files ml/training/statsforecast.py` *(fails: ModuleNotFoundError: No module named 'nautilus_trader.core.data')*
- `pytest ml/tests/unit/test_base_trainer.py -q` *(fails: ModuleNotFoundError: No module named 'nautilus_trader.core.data')*

------
https://chatgpt.com/codex/tasks/task_e_689582c577e083229c75bfe7435d29ea

## Summary by Sourcery

Support explicit validation datasets in the StatsForecast trainer by separating preparation of training and validation data, always using provided validation data for evaluation (with or without Optuna), and falling back to an internal split when no validation data is supplied.

Enhancements:
- Separate data preparation for train_data and val_data, concatenating their train/test splits when val_data is provided
- Always pass the explicit validation set to both the Optuna-based and default training methods
- Retain the existing internal train/validation split only when no val_data is supplied

Documentation:
- Clarify in the train method docstring that val_data will always be used for evaluation regardless of use_optuna