### PR TITLE
refactor: replace prints with logger

### DIFF
--- a/ml/training/neural_forecast.py
+++ b/ml/training/neural_forecast.py
@@ -3,6 +3,7 @@ Neural Forecast trainer supporting time series transformer models with Optuna an
 support.
 """
 
+import logging
 import pickle
 import urllib.error
 import warnings
@@ -21,6 +22,8 @@ from sklearn.metrics import mean_squared_error
 
 
 warnings.filterwarnings("ignore")
+
+logger = logging.getLogger(__name__)
 
 from ..config.settings import Settings
 from ..data.unified_loader import UnifiedNautilusDataLoader
@@ -51,7 +54,9 @@ try:
     NEURALFORECAST_AVAILABLE = True
 except ImportError:
     NEURALFORECAST_AVAILABLE = False
-    print("Warning: NeuralForecast not available. Install with: pip install neuralforecast")
+    logger.warning(
+        "NeuralForecast not available. Install with: pip install neuralforecast"
+    )
 
 
 class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
@@ -394,9 +399,11 @@ class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
             base_config=self.config,
         )
 
-        print("\nOptimization complete!")
-        print(f"Best parameters: {opt_results.best_params}")
-        print(f"Best {optimizer_config.metric_name}: {opt_results.best_value:.4f}")
+        self._log_info("Optimization complete!")
+        self._log_info(f"Best parameters: {opt_results.best_params}")
+        self._log_info(
+            f"Best {optimizer_config.metric_name}: {opt_results.best_value:.4f}"
+        )
 
         # Train final model with best parameters
         best_config = {**self.config, **opt_results.best_params}
@@ -431,7 +438,7 @@ class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
 
         """
         # Prepare data
-        print(f"Preparing data for {self.model_type}...")
+        self._log_info(f"Preparing data for {self.model_type}...")
         train_df, _, feature_names = self.prepare_data(train_data)
         val_df, _, _ = self.prepare_data(val_data)
 
@@ -440,18 +447,18 @@ class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
             val_df[feature] = self.scaler.transform(val_df[[feature]])
 
         # Create model
-        print(f"Creating {self.model_type} model...")
+        self._log_info(f"Creating {self.model_type} model...")
         model = self._create_model(params)
 
         # Create NeuralForecast object
         nf = NeuralForecast(models=[model], freq=self.freq)
 
         # Fit model
-        print(f"Training {self.model_type} model...")
+        self._log_info(f"Training {self.model_type} model...")
         nf.fit(df=train_df, val_size=len(val_df))
 
         # Generate predictions on validation set
-        print("Generating predictions...")
+        self._log_info("Generating predictions...")
         forecasts = nf.predict(df=train_df)
 
         # Calculate metrics
@@ -496,7 +503,7 @@ class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
         )
 
         if len(merged) == 0:
-            print("Warning: No overlapping timestamps for evaluation")
+            self._log_warning("No overlapping timestamps for evaluation")
             return {"val_mse": np.nan, "val_mae": np.nan, "val_mape": np.nan, "val_rmse": np.nan}
 
         # Get model column name (e.g., 'TFT', 'Informer', etc)
@@ -666,8 +673,8 @@ class NeuralForecastTrainer(ResourceManagedTrainerMixin, BaseTrainer):
         with open(latest_path, "wb") as f:
             pickle.dump(model_data, f)
 
-        print(f"\nModel saved to: {model_path}")
-        print(f"Also saved as: {latest_path}")
+        self._log_info(f"Model saved to: {model_path}")
+        self._log_info(f"Also saved as: {latest_path}")
 
         return model_path
 
@@ -727,7 +734,7 @@ def train_tft_model(
         FloatingPointError,
         RuntimeError,
     ) as e:
-        print(f"Error loading data: {e}")
+        logger.error(f"Error loading data: {e}")
         raise
 
     # Ensure timestamp column
@@ -817,7 +824,7 @@ def train_multi_model_ensemble(
         FloatingPointError,
         RuntimeError,
     ) as e:
-        print(f"Error loading data: {e}")
+        logger.error(f"Error loading data: {e}")
         raise
 
     # Ensure timestamp column
@@ -832,9 +839,9 @@ def train_multi_model_ensemble(
     all_results = {}
 
     for model_type in models:
-        print(f"\n{'='*60}")
-        print(f"Training {model_type} model...")
-        print(f"{'='*60}")
+        logger.info(f"{'='*60}")
+        logger.info(f"Training {model_type} model...")
+        logger.info(f"{'='*60}")
 
         # Configure trainer
         config = {
@@ -861,13 +868,17 @@ def train_multi_model_ensemble(
 
             all_results[model_type] = results
 
-            print(f"\n{model_type} Results:")
-            print(f"  MAE: {results['metrics']['val_mae']:.4f}")
-            print(f"  RMSE: {results['metrics']['val_rmse']:.4f}")
-            print(f"  MAPE: {results['metrics']['val_mape']:.2%}")
+            logger.info(f"{model_type} Results:")
+            logger.info(f"MAE: {results['metrics']['val_mae']:.4f}")
+            logger.info(
+                f"RMSE: {results['metrics']['val_rmse']:.4f}"
+            )
+            logger.info(
+                f"MAPE: {results['metrics']['val_mape']:.2%}"
+            )
 
         except (ValueError, TypeError, KeyError, AttributeError, RuntimeError) as e:
-            print(f"Error training {model_type}: {e}")
+            logger.error(f"Error training {model_type}: {e}")
             all_results[model_type] = {"error": str(e)}
 
     return all_results

--- a/ml/training/statsforecast.py
+++ b/ml/training/statsforecast.py
@@ -3,6 +3,7 @@ StatsForecast trainer for fast statistical time series models with hierarchical
 forecasting support.
 """
 
+import logging
 import pickle
 import urllib.error
 import warnings
@@ -23,6 +24,8 @@ from sklearn.model_selection import TimeSeriesSplit
 
 warnings.filterwarnings("ignore")
 
+logger = logging.getLogger(__name__)
+
 # Enhanced imports for diagnostics
 
 import matplotlib.pyplot as plt
@@ -33,8 +36,6 @@ from statsmodels.stats.diagnostic import acorr_ljungbox
 
 from ..config.settings import Settings
 from ..data.unified_loader import UnifiedNautilusDataLoader
-from ..features.feature_engineering import FeatureConfig
-from ..features.feature_engineering import FeatureEngineerV2
 
 # Moved to conditional import to avoid circular dependency
 from ..utils.dataframe_converter import DataFrameConverter
@@ -65,8 +66,8 @@ try:
     STATSFORECAST_AVAILABLE = True
 except ImportError:
     STATSFORECAST_AVAILABLE = False
-    print(
-        "Warning: StatsForecast not available. Install with: pip install statsforecast hierarchicalforecast",
+    logger.warning(
+        "StatsForecast not available. Install with: pip install statsforecast hierarchicalforecast",
     )
 
 
@@ -141,8 +142,6 @@ class StatsForecastTrainer(BaseTrainer):
         self.n_jobs = config.get("n_jobs", -1)
         self.fallback_model = config.get("fallback_model", "Naive")
 
-        # Feature engineering (for exogenous variables if needed)
-        self.feature_engineer = FeatureEngineerV2(config.get("feature_config", FeatureConfig()))
 
     def _infer_season_length(self) -> int:
         """
@@ -189,7 +188,7 @@ class StatsForecastTrainer(BaseTrainer):
                 try:
                     model = model_map[model_name]()
                     models.append(model)
-                    print(f"  Added {model_name} model")
+                    self._log_info(f"Added {model_name} model")
                 except (
                     requests.exceptions.RequestException,
                     urllib.error.URLError,
@@ -197,12 +196,14 @@ class StatsForecastTrainer(BaseTrainer):
                     ValueError,
                     TypeError,
                 ) as e:
-                    print(f"  Warning: Could not create {model_name} model: {e}")
+                    self._log_warning(
+                        f"Could not create {model_name} model: {e}"
+                    )
 
         # Add fallback model if no models created
         if not models and self.fallback_model in model_map:
             models.append(model_map[self.fallback_model]())
-            print(f"  Added fallback {self.fallback_model} model")
+            self._log_info(f"Added fallback {self.fallback_model} model")
 
         return models
 
@@ -318,7 +319,9 @@ class StatsForecastTrainer(BaseTrainer):
         """
         Train models with default parameters.
         """
-        print(f"\nTraining {len(self.model_types)} StatsForecast models...")
+        self._log_info(
+            f"Training {len(self.model_types)} StatsForecast models..."
+        )
 
         # Create models
         self.models = self._create_models()
@@ -327,11 +330,13 @@ class StatsForecastTrainer(BaseTrainer):
         self.forecaster = StatsForecast(models=self.models, freq=self.freq, n_jobs=self.n_jobs)
 
         # Fit models
-        print("Fitting models...")
+        self._log_info("Fitting models...")
         self.forecaster.fit(train_df)
 
         # Generate forecasts
-        print(f"Generating {self.forecast_horizon}-step ahead forecasts...")
+        self._log_info(
+            f"Generating {self.forecast_horizon}-step ahead forecasts..."
+        )
         forecasts = self.forecaster.predict(h=self.forecast_horizon)
 
         # Evaluate on test set if available
@@ -367,7 +372,7 @@ class StatsForecastTrainer(BaseTrainer):
 
         # Calculate ensemble if requested
         if self.use_ensemble and len(self.models) > 1:
-            print("Creating ensemble forecast...")
+            self._log_info("Creating ensemble forecast...")
             model_cols = [type(m).__name__ for m in self.models]
             forecasts["ensemble"] = forecasts[model_cols].mean(axis=1)
 
@@ -396,12 +401,12 @@ class StatsForecastTrainer(BaseTrainer):
 
         # Print metrics
         if metrics:
-            print("\nModel performance:")
+            self._log_info("Model performance:")
             for model_name, model_metrics in metrics.items():
-                print(f"\n{model_name}:")
+                self._log_info(model_name)
                 for metric_name, value in model_metrics.items():
                     if not np.isnan(value):
-                        print(f"  {metric_name}: {value:.4f}")
+                        self._log_info(f"{metric_name}: {value:.4f}")
 
         return {
             "forecaster": self.forecaster,
@@ -429,7 +434,9 @@ class StatsForecastTrainer(BaseTrainer):
         from ..optimization import OptimizerConfig
         from ..optimization.search_spaces import StatsForecastSearchSpace
 
-        print(f"\nOptimizing StatsForecast models with Optuna ({n_trials} trials)...")
+        self._log_info(
+            f"Optimizing StatsForecast models with Optuna ({n_trials} trials)..."
+        )
 
         # Create optimizer
         optimizer_config = OptimizerConfig(
@@ -522,7 +529,9 @@ class StatsForecastTrainer(BaseTrainer):
         best_params = optimizer.optimize(objective)
 
         # Train final model with best parameters
-        print(f"\nTraining final model with best parameters: {best_params}")
+        self._log_info(
+            f"Training final model with best parameters: {best_params}"
+        )
 
         # Create models with best parameters
         self.models = []
@@ -628,7 +637,9 @@ class StatsForecastTrainer(BaseTrainer):
         base_forecasts = results["forecasts"]
 
         # Set up hierarchical reconciliation
-        print(f"\nApplying hierarchical reconciliation ({self.reconciliation_method})...")
+        self._log_info(
+            f"Applying hierarchical reconciliation ({self.reconciliation_method})..."
+        )
 
         # Get reconciliation method
         recon_methods = {
@@ -651,7 +662,7 @@ class StatsForecastTrainer(BaseTrainer):
 
         # Evaluate reconciled forecasts
         if len(test_df) >= self.forecast_horizon:
-            print("\nEvaluating reconciled forecasts...")
+            self._log_info("Evaluating reconciled forecasts...")
 
             # Calculate metrics for reconciled forecasts
             recon_metrics = {}
@@ -753,7 +764,7 @@ class StatsForecastTrainer(BaseTrainer):
 
             # Generate and log diagnostics if test data provided
             if test_df is not None and "forecasts" in results:
-                print("Generating model diagnostics...")
+                self._log_info("Generating model diagnostics...")
 
                 # Generate comprehensive diagnostics
                 diagnostics = self.generate_diagnostics(results, test_df, save_plots=True)
@@ -855,8 +866,8 @@ class StatsForecastTrainer(BaseTrainer):
             import mlflow
 
             run_id = mlflow.active_run().info.run_id
-            print(f"\nModel saved to MLflow: {run_id}")
-            print(f"Model URI: {model_uri}")
+            self._log_info(f"Model saved to MLflow: {run_id}")
+            self._log_info(f"Model URI: {model_uri}")
 
             return run_id
 
@@ -1050,7 +1061,7 @@ class StatsForecastTrainer(BaseTrainer):
 
         if not interval_cols:
             # Add bootstrap-based intervals if not present
-            print("Computing bootstrap prediction intervals...")
+            self._log_info("Computing bootstrap prediction intervals...")
 
             # For each model column
             model_cols = [col for col in forecasts.columns if col not in ["unique_id", "ds", "y"]]
@@ -1136,7 +1147,7 @@ class StatsForecastTrainer(BaseTrainer):
             plt.close()
 
         except (FileNotFoundError, OSError, ValueError, TypeError, RuntimeError) as e:
-            print(f"Error in seasonal decomposition: {e}")
+            self._log_error(f"Error in seasonal decomposition: {e}")
             return None
 
 
@@ -1186,7 +1197,9 @@ def main():
             polars.exceptions.PolarsError,
             RuntimeError,
         ) as e:
-            print(f"Warning: Could not load from catalog, falling back to parquet: {e}")
+            self._log_warning(
+                f"Could not load from catalog, falling back to parquet: {e}"
+            )
             # Fallback: load from parquet file using Polars
             # This is acceptable as it's in fallback logic when catalog is unavailable
             data = pl.read_parquet(data_path)
@@ -1205,13 +1218,15 @@ def main():
             test_df=test_df,
         )
 
-        print(f"\nTraining complete! MLflow run ID: {run_id}")
-        print(f"Best models: {[type(m).__name__ for m in results['models']]}")
+        logger.info(f"Training complete! MLflow run ID: {run_id}")
+        logger.info(
+            f"Best models: {[type(m).__name__ for m in results['models']]}"
+        )
 
         if "metrics" in results:
-            print("\nModel performance:")
+            logger.info("Model performance:")
             for model, metrics in results["metrics"].items():
-                print(f"{model}: RMSE={metrics['rmse']:.4f}")
+                logger.info(f"{model}: RMSE={metrics['rmse']:.4f}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace print calls with logger in NeuralForecastTrainer and StatsForecastTrainer
- drop unused FeatureEngineerV2 from StatsForecast trainer

## Testing
- `python -m py_compile ml/training/neural_forecast.py ml/training/statsforecast.py`
- `pytest ml/tests/unit/test_base_trainer.py -q` *(fails: ModuleNotFoundError: No module named 'nautilus_trader.core.data')*

------
https://chatgpt.com/codex/tasks/task_e_689582c5b20c8322ab1e4e81fa79f0f8

## Summary by Sourcery

Replace ad-hoc print statements with structured logger calls across NeuralForecastTrainer and StatsForecastTrainer, and remove an unused feature engineer in the StatsForecastTrainer.

Enhancements:
- Replace print calls in StatsForecastTrainer with logger methods (info, warning, error) via the new self._log_* wrappers
- Replace print calls in NeuralForecastTrainer with logger methods for consistent logging
- Remove unused FeatureEngineerV2 initialization from StatsForecastTrainer